### PR TITLE
Missing resolution call in the latest versions of Blish HUD (v0.11.1+)

### DIFF
--- a/Pathing/Entities/TrailPathable.cs
+++ b/Pathing/Entities/TrailPathable.cs
@@ -40,10 +40,44 @@ namespace Charr.Timers_BlishHUD.Pathing.Entities
 
         public override void HandleRebuild(GraphicsDevice graphicsDevice) { /* NOOP */ }
 
+        private static BuildTrailWithResolution(List<Vector3> points, float pointResolution)
+        {
+            if (!points.Any())
+            {
+                return new List<Vector3>(0);
+            }
+
+            List<Vector3> tempPoints = new List<Vector3>();
+
+            var lstPoint = points[0];
+
+            for (int i = 0; i<points.Count; i++)
+            {
+                var dist = Vector3.Distance(lstPoint, points[i]);
+
+                var s   = dist / pointResolution;
+                var inc = 1    / s;
+
+                for (float v = inc; v <s - inc; v += inc)
+                {
+                    var nPoint = Vector3.Lerp(lstPoint, points[i], v / s);
+
+                    tempPoints.Add(nPoint);
+                }
+
+                tempPoints.Add(points[i]);
+
+                lstPoint = points[i];
+            }
+
+            return tempPoints;
+        }
+
+        // TODO: When the time comes, this update method has plenty of places where easy optimizations can be made.
         public override void Update(GameTime gameTime) {
             if (!Visible || !ShouldShow) return;
 
-            List <Vector3> trailPoints = new List<Vector3>(new Vector3[] { PointA, PointB }).SetResolution(this.TrailResolution);
+            List <Vector3> trailPoints = BuildTrailWithResolution(new List<Vector3>(new Vector3[] { PointA, PointB }), this.TrailResolution);
 
             _vertexData = new VertexPositionColorTexture[trailPoints.Count * 2];
 


### PR DESCRIPTION
Added in resolution code in the trail class for building out trail points and made a note about future optimizations so that it is easily remembered.  👍